### PR TITLE
Meta information for german translations

### DIFF
--- a/pretix_cashpayment/locale/de/LC_MESSAGES/django.po
+++ b/pretix_cashpayment/locale/de/LC_MESSAGES/django.po
@@ -1,3 +1,11 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 #: pretix_cashpayment/__init__.py:9 pretix_cashpayment/payment.py:14
 msgid "Cash Payment"
 msgstr "Barzahlung"

--- a/pretix_cashpayment/locale/de_Informal/LC_MESSAGES/django.po
+++ b/pretix_cashpayment/locale/de_Informal/LC_MESSAGES/django.po
@@ -1,3 +1,11 @@
+msgid ""
+msgstr ""
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
 #: pretix_cashpayment/__init__.py:9 pretix_cashpayment/payment.py:14
 msgid "Cash Payment"
 msgstr "Barzahlung"


### PR DESCRIPTION
Added meta information about encoding to German translations. `manage.py compilejsi18n`, which is part of pretix' `make production` fails otherwise with encoding errors.